### PR TITLE
fix(backend): fix returned model id(#5).

### DIFF
--- a/backend/src/api/v1/models.ts
+++ b/backend/src/api/v1/models.ts
@@ -12,7 +12,7 @@ export const modelsQueryApi = new Elysia().get("/models", async ({ error }) => {
   return {
     object: "list",
     data: upstreams.map((upstream) => ({
-      id: upstream.id,
+      id: upstream.model,
       object: "model",
       created: upstream.createdAt.getTime(),
       owned_by: upstream.name,


### PR DESCRIPTION
This pull request is a little fix to correct the returned model id. It has been tested.
`{"object":"list","data":[{"id":"deepseek-r1","object":"model","created":1742186204000,"owned_by":"DeepSeek"}]}`