### PR TITLE
feat(backend): Remove @Provider from the request page model name

### DIFF
--- a/backend/src/api/admin/completions.ts
+++ b/backend/src/api/admin/completions.ts
@@ -5,12 +5,19 @@ export const adminCompletions = new Elysia()
   .get(
     "/completions",
     async ({ query }) => {
-      return await listCompletions(
+      const result = await listCompletions(
         query.offset ?? 0,
         query.limit ?? 100,
         query.apiKeyId,
         query.upstreamId,
       );
+      // 如果 model 字段存在且包含 '@'，则截断
+      result.data.forEach((completion) => {
+        if (completion.model && completion.model.includes("@")) {
+          completion.model = completion.model.split("@")[0];
+        }
+      });
+      return result;
     },
     {
       query: t.Object({
@@ -28,6 +35,10 @@ export const adminCompletions = new Elysia()
       const r = await findCompletion(id);
       if (r === null) {
         return error(404, "Completion not found");
+      }
+      // 如果 model 字段存在且包含 '@'，则截断
+      if (r.model && r.model.includes("@")) {
+        r.model = r.model.split("@")[0];
       }
       return r;
     },

--- a/backend/src/api/admin/rateLimits.ts
+++ b/backend/src/api/admin/rateLimits.ts
@@ -1,4 +1,9 @@
-import { getAllRateLimits, getRateLimitConfig, setRateLimitConfig, deleteRateLimitConfig } from "@/utils/rateLimitConfig";
+import {
+  getAllRateLimits,
+  getRateLimitConfig,
+  setRateLimitConfig,
+  deleteRateLimitConfig,
+} from "@/utils/rateLimitConfig";
 import Elysia, { t } from "elysia";
 
 export const adminRateLimits = new Elysia()
@@ -26,16 +31,16 @@ export const adminRateLimits = new Elysia()
     async ({ body, error, set }) => {
       const { identifier, ...config } = body;
       const existing = getRateLimitConfig(identifier);
-      
+
       if (existing && Object.keys(existing).length > 0) {
         return error(409, "Rate limit configuration already exists");
       }
-      
+
       const success = setRateLimitConfig(identifier, config);
       if (!success) {
         return error(500, "Failed to create rate limit configuration");
       }
-      
+
       set.status = 201;
       return { identifier, ...config };
     },
@@ -53,16 +58,16 @@ export const adminRateLimits = new Elysia()
     async ({ params, error, set }) => {
       const { identifier } = params;
       const existing = getRateLimitConfig(identifier);
-      
+
       if (!existing || Object.keys(existing).length === 0) {
         return error(404, "Rate limit configuration not found");
       }
-      
+
       const success = deleteRateLimitConfig(identifier);
       if (!success) {
         return error(500, "Failed to delete rate limit configuration");
       }
-      
+
       set.status = 204;
       return null;
     },


### PR DESCRIPTION
对 #17 的实现 
主要修改了api/admin/completions 及api/admin/completions/{id} 的逻辑
在返回时检查模型名称是否有@，如果有则去除@及后面的provider
另外在提交前biome发现同目录的rateLimits.ts存在格式问题，同时提交了
Implementation of #17
Main modifications were made to the logic of api/admin/completions and api/admin/completions/{id}
Check if the model name contains @ when returning, and if it does, remove @ and the following provider
Additionally, before submission, the biome found that there are formatting issues in the rateLimits.ts file in the same directory, and it was submitted accordingly.