### PR TITLE
fix(backend): implement weighted load balancing in selectModel

### DIFF
--- a/backend/src/utils/api-helpers.ts
+++ b/backend/src/utils/api-helpers.ts
@@ -81,6 +81,7 @@ export function extractUpstreamHeaders(
 
 /**
  * Select the best model/provider combination based on target provider and weights
+ * Uses weighted random selection for load balancing across multiple providers
  */
 export function selectModel(
   modelsWithProviders: ModelWithProvider[],
@@ -105,8 +106,33 @@ export function selectModel(
     }
   }
 
-  // TODO: implement weighted load balancing
-  return candidates[0] || null;
+  // Single candidate, return directly
+  if (candidates.length === 1) {
+    // oxlint-disable-next-line no-unnecessary-type-assertion
+    return candidates[0]!; // TypeScript needs assertion here
+  }
+
+  // Weighted random selection for load balancing
+  const totalWeight = candidates.reduce((sum, c) => sum + c.model.weight, 0);
+  const random = Math.random() * totalWeight;
+
+  let cumulative = 0;
+  for (const candidate of candidates) {
+    cumulative += candidate.model.weight;
+    if (random < cumulative) {
+      logger.debug("Selected model via weighted random", {
+        modelId: candidate.model.id,
+        providerId: candidate.provider.id,
+        providerName: candidate.provider.name,
+        weight: candidate.model.weight,
+        totalWeight,
+      });
+      return candidate;
+    }
+  }
+
+  // Fallback (should not happen)
+  return candidates[0] ?? null;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Fixed the `selectModel` function in `api-helpers.ts` that was ignoring weight configuration
- Previously, the function had a `TODO: implement weighted load balancing` comment but only returned the first candidate
- Now implements proper weighted random selection algorithm matching the implementation in `utils/model.ts`

## Problem

When multiple providers offered the same model with different weights (e.g., provider-A weight=1, provider-B weight=2, provider-C weight=3), all requests were routed to provider-A (100%) instead of being distributed according to weights (~16.7%, ~33.3%, ~50.0%).

## Test Results

| Scenario | provider-A (w=1) | provider-B (w=2) | provider-C (w=3) |
|----------|------------------|------------------|------------------|
| Expected | ~16.7% | ~33.3% | ~50.0% |
| Before fix | 100% ❌ | 0% | 0% |
| After fix | 16.9% ✅ | 32.4% ✅ | 50.7% ✅ |

## Affected Endpoints

- `/v1/chat/completions`
- `/v1/messages`
- `/v1/responses`

Note: `/v1/embeddings` was already using the correct weighted selection from `utils/model.ts`.

## Test plan

- [x] Verified with simulation test script (`scripts/test-selectmodel-comparison.ts`)
- [x] Type check passes (`bun run check`)
- [x] Lint passes (`bun run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改进

* **改进**
  * 升级模型选择机制，实现加权随机负载均衡算法，在多个可用模型间更智能地分配请求，提高系统稳定性和可靠性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->