### PR TITLE
fix: handle streaming usage chunk and soft-deleted provider filtering

### DIFF
--- a/backend/src/adapters/upstream/openai.ts
+++ b/backend/src/adapters/upstream/openai.ts
@@ -11,8 +11,7 @@ import type {
   InternalResponse,
   InternalStreamChunk,
   InternalToolDefinition,
-  InternalUsage,
-  ProviderConfig,
+ProviderConfig,
   StopReason,
   TextContentBlock,
   ThinkingContentBlock,
@@ -387,7 +386,7 @@ export const openaiUpstreamAdapter: UpstreamAdapter = {
 
   buildRequest(
     request: InternalRequest,
-    provider: ProviderConfig,
+    provider:  ProviderConfig,
   ): { url: string; init: RequestInit } {
     // Build messages array with system prompt
     const messages: OpenAIMessage[] = [];
@@ -510,6 +509,18 @@ export const openaiUpstreamAdapter: UpstreamAdapter = {
 
       const choice = data.choices[0];
       if (!choice) {
+        // Usage-only chunk (choices=[]) — some providers send usage separately
+        // after the finish_reason chunk when stream_options.include_usage=true
+        if (data.usage) {
+          yield {
+            type: "message_delta",
+            messageDelta: { stopReason: null },
+            usage: {
+              inputTokens: data.usage.prompt_tokens,
+              outputTokens: data.usage.completion_tokens,
+            },
+          };
+        }
         continue;
       }
 
@@ -581,18 +592,20 @@ export const openaiUpstreamAdapter: UpstreamAdapter = {
       // Handle finish reason
       if (choice.finish_reason) {
         yield { type: "content_block_stop", index: blockIndex };
-        const usage: InternalUsage = data.usage
-          ? {
-              inputTokens: data.usage.prompt_tokens,
-              outputTokens: data.usage.completion_tokens,
-            }
-          : { inputTokens: -1, outputTokens: -1 };
+        // Include usage only if upstream provided it in this chunk.
+        // Some providers bundle usage with finish_reason; others send a
+        // separate usage-only chunk (choices=[]) immediately after.
         yield {
           type: "message_delta",
           messageDelta: {
             stopReason: convertFinishReason(choice.finish_reason),
           },
-          usage,
+          ...(data.usage && {
+            usage: {
+              inputTokens: data.usage.prompt_tokens,
+              outputTokens: data.usage.completion_tokens,
+            },
+          }),
         };
       }
     }

--- a/backend/src/adapters/upstream/openai.ts
+++ b/backend/src/adapters/upstream/openai.ts
@@ -514,7 +514,6 @@ export const openaiUpstreamAdapter: UpstreamAdapter = {
         if (data.usage) {
           yield {
             type: "message_delta",
-            messageDelta: { stopReason: null },
             usage: {
               inputTokens: data.usage.prompt_tokens,
               outputTokens: data.usage.completion_tokens,

--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -955,9 +955,14 @@ export async function listUniqueSystemNames(
   const r = await db
     .selectDistinct({ systemName: schema.ModelsTable.systemName })
     .from(schema.ModelsTable)
+    .innerJoin(
+      schema.ProvidersTable,
+      eq(schema.ModelsTable.providerId, schema.ProvidersTable.id),
+    )
     .where(
       and(
         not(schema.ModelsTable.deleted),
+        not(schema.ProvidersTable.deleted),
         modelType ? eq(schema.ModelsTable.modelType, modelType) : undefined,
       ),
     )


### PR DESCRIPTION
## Summary

- **fix(adapters): handle separate usage chunk in OpenAI streaming responses** — Some OpenAI-compatible providers send token usage in a separate chunk (`choices=[]`) after the `finish_reason` chunk, rather than bundling them together. Previously this chunk was silently skipped, causing streaming token counts to always be `-1`. Now both patterns are supported.
- **fix(db): filter soft-deleted providers in listUniqueSystemNames** — `listUniqueSystemNames()` did not join/filter the providers table for soft-delete, causing models from deleted providers to appear in the global model registry with "no providers" shown in the UI.

## Test plan

- [ ] Verify streaming requests to OpenAI-compatible APIs record correct `promptTokens` / `completionTokens` in the database (no longer `-1`)
- [ ] Verify TPM rate limiting works correctly for streaming requests
- [ ] Delete a provider, create a new provider with the same model name, confirm the global models page shows the model correctly with the new provider
- [ ] Confirm non-streaming requests are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化了流式响应中使用数据的处理逻辑，确保仅在实际可用时发送相关信息，避免空字段。
  * 改进了系统名称查询逻辑，现仅基于有效的提供方记录，提升结果一致性与准确性。

* **Chores**
  * 进行了不影响运行的公共类型导出调整。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->