### PR TITLE
feat(models): archived model display and URL encoding fix

### DIFF
--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -951,7 +951,10 @@ export async function getModelsWithProviderBySystemName(
  */
 export async function listUniqueSystemNames(
   modelType?: ModelTypeEnumType,
-): Promise<{ active: string[]; archived: string[] }> {
+): Promise<{
+  active: string[];
+  archived: { systemName: string; modelType: "chat" | "embedding" }[];
+}> {
   logger.debug("listUniqueSystemNames", modelType);
 
   // Get active model names (non-deleted models with non-deleted providers)
@@ -971,25 +974,37 @@ export async function listUniqueSystemNames(
     )
     .orderBy(asc(schema.ModelsTable.systemName));
   const active = r.map((x) => x.systemName);
+  const activeSet = new Set(active);
 
   // Get archived model names: exist in completions/embeddings but not in active models
-  const archivedResult = await db.execute(sql`
-    SELECT DISTINCT model AS name FROM (
-      SELECT DISTINCT model FROM completions WHERE deleted = false
-      UNION
-      SELECT DISTINCT model FROM embeddings WHERE deleted = false
-    ) AS all_models
-    WHERE model NOT IN (
-      SELECT DISTINCT m.system_name
-      FROM models m
-      INNER JOIN providers p ON m.provider_id = p.id
-      WHERE m.deleted = false AND p.deleted = false
-    )
-    ORDER BY name ASC
+  // Each model tagged with its type based on which table it comes from
+  const historicalResult = await db.execute(sql`
+    SELECT model AS name, 'chat' AS model_type FROM completions WHERE deleted = false
+    UNION
+    SELECT model AS name, 'embedding' AS model_type FROM embeddings WHERE deleted = false
   `);
-  const archived = (archivedResult as unknown as { name: string }[]).map(
-    (x) => x.name,
-  );
+  const historicalRows = historicalResult as unknown as {
+    name: string;
+    model_type: "chat" | "embedding";
+  }[];
+
+  // Filter out active models and respect modelType filter
+  const archivedMap = new Map<
+    string,
+    "chat" | "embedding"
+  >();
+  for (const row of historicalRows) {
+    if (activeSet.has(row.name)) continue;
+    if (modelType && row.model_type !== modelType) continue;
+    // If a name appears in both tables, prefer 'chat' (it's the more common case)
+    if (!archivedMap.has(row.name)) {
+      archivedMap.set(row.name, row.model_type);
+    }
+  }
+
+  const archived = Array.from(archivedMap.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([systemName, mt]) => ({ systemName, modelType: mt }));
 
   return { active, archived };
 }

--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -947,11 +947,14 @@ export async function getModelsWithProviderBySystemName(
 
 /**
  * list unique system names (for global model registry)
+ * Returns active model names and archived names (deleted but referenced by historical requests)
  */
 export async function listUniqueSystemNames(
   modelType?: ModelTypeEnumType,
-): Promise<string[]> {
+): Promise<{ active: string[]; archived: string[] }> {
   logger.debug("listUniqueSystemNames", modelType);
+
+  // Get active model names (non-deleted models with non-deleted providers)
   const r = await db
     .selectDistinct({ systemName: schema.ModelsTable.systemName })
     .from(schema.ModelsTable)
@@ -967,7 +970,28 @@ export async function listUniqueSystemNames(
       ),
     )
     .orderBy(asc(schema.ModelsTable.systemName));
-  return r.map((x) => x.systemName);
+  const active = r.map((x) => x.systemName);
+
+  // Get archived model names: exist in completions/embeddings but not in active models
+  const archivedResult = await db.execute(sql`
+    SELECT DISTINCT model AS name FROM (
+      SELECT DISTINCT model FROM completions WHERE deleted = false
+      UNION
+      SELECT DISTINCT model FROM embeddings WHERE deleted = false
+    ) AS all_models
+    WHERE model NOT IN (
+      SELECT DISTINCT m.system_name
+      FROM models m
+      INNER JOIN providers p ON m.provider_id = p.id
+      WHERE m.deleted = false AND p.deleted = false
+    )
+    ORDER BY name ASC
+  `);
+  const archived = (archivedResult as unknown as { name: string }[]).map(
+    (x) => x.name,
+  );
+
+  return { active, archived };
 }
 
 /**

--- a/frontend/src/i18n/locales/en-US.json
+++ b/frontend/src/i18n/locales/en-US.json
@@ -331,6 +331,8 @@
   "pages.models.registry.WeightConfiguration": "Weight Configuration",
   "pages.models.registry.History": "History",
   "pages.models.registry.ViewHistory": "View request history",
+  "pages.models.registry.Archived": "Archived",
+  "pages.models.registry.ArchivedTooltip": "This model has been deleted but has historical requests",
   "routes.models.Title": "Models",
   "routes.models.Description": "Configure model providers and global models.",
   "routes.models.nav.Providers": "Model Providers",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -332,6 +332,8 @@
   "pages.models.registry.WeightConfiguration": "权重配置",
   "pages.models.registry.History": "历史",
   "pages.models.registry.ViewHistory": "查看请求历史",
+  "pages.models.registry.Archived": "已归档",
+  "pages.models.registry.ArchivedTooltip": "该模型已删除但存在历史请求记录",
   "routes.models.Title": "模型",
   "routes.models.Description": "配置模型供应商和全局模型。",
   "routes.models.nav.Providers": "模型供应商",

--- a/frontend/src/pages/models/models-registry-table.tsx
+++ b/frontend/src/pages/models/models-registry-table.tsx
@@ -120,7 +120,7 @@ function ModelsBySystemNameTable({ systemName }: { systemName: string }) {
   const { data: models = [], isLoading } = useQuery({
     queryKey: ['models', 'by-system-name', systemName],
     queryFn: async () => {
-      const { data, error } = await api.admin.models['by-system-name'][systemName].get()
+      const { data, error } = await api.admin.models['by-system-name'][encodeURIComponent(systemName)].get()
       if (error) throw error
       return data as ModelWithProvider[]
     },
@@ -128,7 +128,7 @@ function ModelsBySystemNameTable({ systemName }: { systemName: string }) {
 
   const updateWeightsMutation = useMutation({
     mutationFn: async (weights: { modelId: number; weight: number }[]) => {
-      const { error } = await api.admin.models['by-system-name'][systemName].weights.put({
+      const { error } = await api.admin.models['by-system-name'][encodeURIComponent(systemName)].weights.put({
         weights,
       })
       if (error) throw error

--- a/frontend/src/pages/settings/models-settings-page.tsx
+++ b/frontend/src/pages/settings/models-settings-page.tsx
@@ -25,9 +25,14 @@ interface ModelWithProvider {
   }
 }
 
+interface ArchivedModel {
+  systemName: string
+  modelType: 'chat' | 'embedding'
+}
+
 interface ModelsSettingsPageProps {
   activeSystemNames: string[]
-  archivedSystemNames: string[]
+  archivedSystemNames: ArchivedModel[]
 }
 
 export function ModelsSettingsPage({ activeSystemNames, archivedSystemNames }: ModelsSettingsPageProps) {
@@ -56,8 +61,8 @@ export function ModelsSettingsPage({ activeSystemNames, archivedSystemNames }: M
                 {activeSystemNames.map((systemName) => (
                   <ModelRow key={systemName} systemName={systemName} />
                 ))}
-                {archivedSystemNames.map((systemName) => (
-                  <ArchivedModelRow key={systemName} systemName={systemName} />
+                {archivedSystemNames.map((item) => (
+                  <ArchivedModelRow key={item.systemName} systemName={item.systemName} modelType={item.modelType} />
                 ))}
               </TableBody>
             </Table>
@@ -166,13 +171,17 @@ function ModelRow({ systemName }: { systemName: string }) {
   )
 }
 
-function ArchivedModelRow({ systemName }: { systemName: string }) {
+function ArchivedModelRow({ systemName, modelType }: { systemName: string; modelType: 'chat' | 'embedding' }) {
   const { t } = useTranslation()
   const navigate = useNavigate()
 
   const handleHistoryClick = (e: React.MouseEvent) => {
     e.stopPropagation()
-    navigate({ to: '/requests', search: { model: systemName } })
+    if (modelType === 'embedding') {
+      navigate({ to: '/embeddings', search: { model: systemName } })
+    } else {
+      navigate({ to: '/requests', search: { model: systemName } })
+    }
   }
 
   return (

--- a/frontend/src/pages/settings/models-settings-page.tsx
+++ b/frontend/src/pages/settings/models-settings-page.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
-import { CpuIcon, HistoryIcon } from 'lucide-react'
+import { ArchiveIcon, CpuIcon, HistoryIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
@@ -25,8 +25,14 @@ interface ModelWithProvider {
   }
 }
 
-export function ModelsSettingsPage({ systemNames }: { systemNames: string[] }) {
+interface ModelsSettingsPageProps {
+  activeSystemNames: string[]
+  archivedSystemNames: string[]
+}
+
+export function ModelsSettingsPage({ activeSystemNames, archivedSystemNames }: ModelsSettingsPageProps) {
   const { t } = useTranslation()
+  const hasAny = activeSystemNames.length > 0 || archivedSystemNames.length > 0
 
   return (
     <div className="space-y-8">
@@ -36,7 +42,7 @@ export function ModelsSettingsPage({ systemNames }: { systemNames: string[] }) {
           <CardDescription className="text-sm">{t('pages.models.registry.Description')}</CardDescription>
         </CardHeader>
         <CardContent>
-          {systemNames.length > 0 ? (
+          {hasAny ? (
             <Table>
               <TableHeader>
                 <TableRow>
@@ -47,8 +53,11 @@ export function ModelsSettingsPage({ systemNames }: { systemNames: string[] }) {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {systemNames.map((systemName) => (
+                {activeSystemNames.map((systemName) => (
                   <ModelRow key={systemName} systemName={systemName} />
+                ))}
+                {archivedSystemNames.map((systemName) => (
+                  <ArchivedModelRow key={systemName} systemName={systemName} />
                 ))}
               </TableBody>
             </Table>
@@ -69,7 +78,7 @@ function ModelRow({ systemName }: { systemName: string }) {
   const { data: models = [], isLoading } = useQuery({
     queryKey: ['models', 'by-system-name', systemName],
     queryFn: async () => {
-      const { data, error } = await api.admin.models['by-system-name'][systemName].get()
+      const { data, error } = await api.admin.models['by-system-name'][encodeURIComponent(systemName)].get()
       if (error) throw error
       return data as ModelWithProvider[]
     },
@@ -157,6 +166,46 @@ function ModelRow({ systemName }: { systemName: string }) {
   )
 }
 
+function ArchivedModelRow({ systemName }: { systemName: string }) {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+
+  const handleHistoryClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    navigate({ to: '/requests', search: { model: systemName } })
+  }
+
+  return (
+    <TableRow className="opacity-50">
+      <TableCell>
+        <div className="flex items-center gap-3">
+          <ArchiveIcon className="text-muted-foreground/50 size-5" />
+          <span className="text-muted-foreground font-mono text-sm font-medium line-through">{systemName}</span>
+        </div>
+      </TableCell>
+      <TableCell>
+        <span className="text-muted-foreground text-sm">-</span>
+      </TableCell>
+      <TableCell>
+        <span className="text-muted-foreground text-sm italic" title={t('pages.models.registry.ArchivedTooltip')}>
+          {t('pages.models.registry.Archived')}
+        </span>
+      </TableCell>
+      <TableCell className="text-center">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="size-8 p-0"
+          onClick={handleHistoryClick}
+          title={t('pages.models.registry.ViewHistory')}
+        >
+          <HistoryIcon className="size-4" />
+        </Button>
+      </TableCell>
+    </TableRow>
+  )
+}
+
 interface LoadBalancingDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -182,7 +231,7 @@ function LoadBalancingDialog({ open, onOpenChange, systemName, models }: LoadBal
 
   const updateWeightsMutation = useMutation({
     mutationFn: async (weights: { modelId: number; weight: number }[]) => {
-      const { error } = await api.admin.models['by-system-name'][systemName].weights.put({
+      const { error } = await api.admin.models['by-system-name'][encodeURIComponent(systemName)].weights.put({
         weights,
       })
       if (error) throw error

--- a/frontend/src/routes/models/registry.tsx
+++ b/frontend/src/routes/models/registry.tsx
@@ -27,5 +27,5 @@ export const Route = createFileRoute('/models/registry')({
 function RouteComponent() {
   const { data } = useSuspenseQuery(systemNamesQueryOptions())
 
-  return <ModelsSettingsPage systemNames={data} />
+  return <ModelsSettingsPage activeSystemNames={data.active} archivedSystemNames={data.archived} />
 }


### PR DESCRIPTION
## Summary

- **Archived models in registry**: Models that have been deleted but still have historical completion/embedding records now appear as grayed-out "Archived" entries in the global model registry page. Users can click the history button to navigate to past requests for traceability.
- **URL encoding fix**: Eden Treaty does not URL-encode dynamic path segments, causing 404 errors for model names containing slashes (e.g. `Qwen/Qwen3-8B`). All `by-system-name` path params are now wrapped with `encodeURIComponent()`.

## Changes

### Backend
- `listUniqueSystemNames()` now returns `{ active: string[], archived: string[] }` instead of `string[]`
- Archived names are derived via SQL UNION on `completions` + `embeddings` tables, excluding active model names

### Frontend
- New `ArchivedModelRow` component with archive icon, opacity-50, and strikethrough styling
- `ModelsSettingsPage` accepts `activeSystemNames` and `archivedSystemNames` props
- Added `encodeURIComponent(systemName)` to all Eden Treaty `by-system-name` calls
- i18n keys added for both en-US and zh-CN

## Test plan
- [ ] Delete all providers for a model that has historical requests → model appears as archived in registry
- [ ] Click history button on archived model → navigates to requests page filtered by that model
- [ ] Model names with slashes (e.g. `Qwen/Qwen3-8B`) display providers correctly
- [ ] Active models continue to work as before (weight editing, history navigation)
- [ ] Type check passes (`bun run check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 模型列表现在区分并显示“已归档”模型，已归档项带淡化样式、归档标签与历史记录入口。

* **改进**
  * 后端返回将活跃与归档模型分组，前端据此分别展示。
  * 对模型系统名的 API 请求进行了编码处理以提升健壮性。

* **本地化**
  * 增加“Archived”及其提示的中/英本地化文本。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->