### PR TITLE
fix(backend): prevent static file path traversal

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -27,6 +27,7 @@ import {
   PRODUCTION,
 } from "@/utils/config";
 import { initConfig } from "./utils/init";
+import { resolveStaticPath } from "@/utils/staticFile";
 
 await initConfig();
 
@@ -62,7 +63,12 @@ function getMimeType(filePath: string): string {
   return mimeTypes[ext || ""] || "application/octet-stream";
 }
 
-async function serveStaticFile(filePath: string) {
+async function serveStaticFile(rootDir: string, requestPath: string) {
+  const filePath = resolveStaticPath(rootDir, requestPath);
+  if (!filePath) {
+    return null;
+  }
+
   try {
     const fileStat = await stat(filePath);
     if (fileStat.isFile()) {
@@ -91,7 +97,7 @@ async function docsPlugin(dir: string) {
       // Handle TanStack Start's __tsr static server function cache requests
       // These are requested from root path, not /docs/
       .get("/__tsr/*", async ({ path, status }) => {
-        const response = await serveStaticFile(join(dir, path));
+        const response = await serveStaticFile(dir, path);
         return response || status(404);
       })
       .get("/docs", ({ status }) => {
@@ -107,17 +113,15 @@ async function docsPlugin(dir: string) {
           return status(404);
         }
         const subPath = path.replace("/docs", "");
-        const exactPath = join(dir, subPath);
-
         // Try to serve as static file
-        const staticResponse = await serveStaticFile(exactPath);
+        const staticResponse = await serveStaticFile(dir, subPath);
         if (staticResponse) {
           return staticResponse;
         }
 
         // Check if there's a specific HTML file for this path (directory with index.html)
-        const specificHtmlPath = join(dir, subPath, "index.html");
-        if (await exists(specificHtmlPath)) {
+        const specificHtmlPath = resolveStaticPath(dir, `${subPath}/index.html`);
+        if (specificHtmlPath && (await exists(specificHtmlPath))) {
           const html = await readFile(specificHtmlPath, "utf-8");
           return new Response(html, {
             headers: { "Content-Type": "text/html" },
@@ -166,7 +170,7 @@ async function spaPlugin(dir: string) {
       }
 
       // Try to serve as static file first
-      const staticResponse = await serveStaticFile(join(dir, path));
+      const staticResponse = await serveStaticFile(dir, path);
       if (staticResponse) {
         return staticResponse;
       }

--- a/backend/src/utils/staticFile.test.ts
+++ b/backend/src/utils/staticFile.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { resolveStaticPath } from "./staticFile";
+
+describe("resolveStaticPath", () => {
+  test("resolves request paths inside the static root", () => {
+    expect(resolveStaticPath("/app/public", "/assets/main.js")).toBe(
+      "/app/public/assets/main.js",
+    );
+  });
+
+  test("allows the static root itself", () => {
+    expect(resolveStaticPath("/app/public", "/")).toBe("/app/public");
+  });
+
+  test("blocks parent-directory traversal", () => {
+    expect(resolveStaticPath("/app/public", "/../../etc/passwd")).toBeNull();
+  });
+
+  test("blocks traversal without a leading slash", () => {
+    expect(resolveStaticPath("/app/public", "../../etc/passwd")).toBeNull();
+  });
+
+  test("normalizes dot segments that stay inside the root", () => {
+    expect(resolveStaticPath("/app/public", "/assets/../index.html")).toBe(
+      "/app/public/index.html",
+    );
+  });
+});

--- a/backend/src/utils/staticFile.ts
+++ b/backend/src/utils/staticFile.ts
@@ -1,0 +1,17 @@
+import { isAbsolute, relative, resolve } from "node:path";
+
+export function resolveStaticPath(
+  rootDir: string,
+  requestPath: string,
+): string | null {
+  const resolvedRoot = resolve(rootDir);
+  const normalizedRequestPath = requestPath.replace(/^\/+/u, "");
+  const resolvedPath = resolve(resolvedRoot, normalizedRequestPath);
+  const relativePath = relative(resolvedRoot, resolvedPath);
+
+  if (relativePath.startsWith("..") || isAbsolute(relativePath)) {
+    return null;
+  }
+
+  return resolvedPath;
+}


### PR DESCRIPTION
### Motivation

- A custom static file server was joining untrusted request paths to asset directories without normalization or a root-boundary check, allowing path traversal and arbitrary file reads from the filesystem.

### Description

- Add a bounded resolver `resolveStaticPath(rootDir, requestPath)` in `backend/src/utils/staticFile.ts` that normalizes the request path, resolves it against the static root, and returns `null` if the resolved path escapes the root.
- Update `serveStaticFile` in `backend/src/index.ts` to accept a `rootDir` and `requestPath`, call `resolveStaticPath`, and only `stat`/`readFile` when the resolved path is inside the static root.
- Replace unsafe `join(dir, path)` usages in the docs and SPA handlers so they call `serveStaticFile(dir, path)` and use `resolveStaticPath` for directory `index.html` lookups to enforce the same boundary.
- Add focused regression tests in `backend/src/utils/staticFile.test.ts` to validate allowed in-root resolution and blocked traversal attempts.

### Testing

- Ran the focused unit tests with `bun --cwd backend test src/utils/staticFile.test.ts`, and all tests passed.
- Attempted `bun --cwd backend test src/utils/staticFile.test.ts src/utils/json.test.ts`, which failed due to an unrelated missing runtime dependency (`@loglayer/transport-simple-pretty-terminal`) in the current environment, not due to these changes.
- Ran `bun --cwd backend check`, which fails in the container because project dependencies/types are not installed, producing pre-existing type/module resolution errors unrelated to the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69be341fc43083288aa0fe0d2b499392)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了静态文件路径解析的安全验证机制

* **Tests**
  * 为静态文件路径处理添加了全面的测试覆盖

<!-- end of auto-generated comment: release notes by coderabbit.ai -->