### PR TITLE
fix(docs): prevent path traversal in /docs static handler

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -15,6 +15,7 @@ async function exists(path: string): Promise<boolean> {
   }
 }
 import { join } from "node:path";
+import { resolvePathWithinBase } from "@/utils/safePath";
 import { routes } from "@/api";
 import { metricsApi } from "@/api/metrics";
 import { loggerPlugin } from "@/plugins/loggerPlugin";
@@ -91,7 +92,12 @@ async function docsPlugin(dir: string) {
       // Handle TanStack Start's __tsr static server function cache requests
       // These are requested from root path, not /docs/
       .get("/__tsr/*", async ({ path, status }) => {
-        const response = await serveStaticFile(join(dir, path));
+        const filePath = resolvePathWithinBase(dir, path);
+        if (!filePath) {
+          return status(404);
+        }
+
+        const response = await serveStaticFile(filePath);
         return response || status(404);
       })
       .get("/docs", ({ status }) => {
@@ -107,7 +113,10 @@ async function docsPlugin(dir: string) {
           return status(404);
         }
         const subPath = path.replace("/docs", "");
-        const exactPath = join(dir, subPath);
+        const exactPath = resolvePathWithinBase(dir, subPath);
+        if (!exactPath) {
+          return status(404);
+        }
 
         // Try to serve as static file
         const staticResponse = await serveStaticFile(exactPath);
@@ -116,8 +125,11 @@ async function docsPlugin(dir: string) {
         }
 
         // Check if there's a specific HTML file for this path (directory with index.html)
-        const specificHtmlPath = join(dir, subPath, "index.html");
-        if (await exists(specificHtmlPath)) {
+        const specificHtmlPath = resolvePathWithinBase(
+          dir,
+          join(subPath, "index.html"),
+        );
+        if (specificHtmlPath && (await exists(specificHtmlPath))) {
           const html = await readFile(specificHtmlPath, "utf-8");
           return new Response(html, {
             headers: { "Content-Type": "text/html" },

--- a/backend/src/utils/safePath.test.ts
+++ b/backend/src/utils/safePath.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import { resolvePathWithinBase } from "./safePath";
+
+describe("resolvePathWithinBase", () => {
+  const baseDir = resolve("/tmp/docs-base");
+
+  test("resolves nested relative paths inside the base directory", () => {
+    expect(resolvePathWithinBase(baseDir, "/assets/app.js")).toBe(
+      resolve(baseDir, "assets/app.js"),
+    );
+  });
+
+  test("keeps base directory requests inside the base directory", () => {
+    expect(resolvePathWithinBase(baseDir, "/")).toBe(baseDir);
+  });
+
+  test("rejects traversal outside the base directory", () => {
+    expect(resolvePathWithinBase(baseDir, "/../../etc/passwd")).toBeNull();
+  });
+
+  test("contains repeated leading slashes within the base directory", () => {
+    expect(resolvePathWithinBase(baseDir, "//etc/passwd")).toBe(
+      resolve(baseDir, "etc/passwd"),
+    );
+  });
+});

--- a/backend/src/utils/safePath.ts
+++ b/backend/src/utils/safePath.ts
@@ -1,0 +1,18 @@
+import { resolve } from "node:path";
+
+export function resolvePathWithinBase(
+  baseDir: string,
+  requestPath: string,
+): string | null {
+  const normalizedRequestPath = requestPath.replaceAll("\\", "/");
+  const pathSegments = normalizedRequestPath
+    .replace(/^\/+/, "")
+    .split("/")
+    .filter(Boolean);
+
+  if (pathSegments.includes("..")) {
+    return null;
+  }
+
+  return resolve(baseDir, ...pathSegments);
+}


### PR DESCRIPTION
### Motivation
- The `/docs/*` handler constructed filesystem paths from request paths without normalization or traversal checks, allowing unauthenticated arbitrary file reads outside the docs directory.
- The `__tsr` asset route used the same unsafe pattern and remained exposed.

### Description
- Add a small containment helper `resolvePathWithinBase` in `backend/src/utils/safePath.ts` that normalizes request paths, rejects `..` segments, and resolves into the configured base directory.
- Use `resolvePathWithinBase` in `backend/src/index.ts` for the `/docs/*` handler and the `/__tsr/*` asset route to return `404` when a path would escape the docs directory instead of reading arbitrary files.
- Add focused regression tests in `backend/src/utils/safePath.test.ts` covering in-base resolution, root requests, traversal rejection, and repeated leading slashes.

### Testing
- Ran the focused unit test with `bun test ./src/utils/safePath.test.ts`, which passed all tests.
- Ran `git diff --check` to validate the diff, which reported no whitespace errors.
- Attempted `bun run check` for broader type checks, which failed due to missing repository dependencies/type definitions in the environment (pre-existing module resolution/type errors unrelated to this patch).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69be341ac374832896a70da99b42c1b6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 改进了静态文件提供机制，增强了文件路径处理的可靠性。

* **测试**
  * 添加了文件路径解析的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->