### PR TITLE
fix(api): restore SSE Content-Type for streaming responses

### DIFF
--- a/backend/src/api/v1/completions.ts
+++ b/backend/src/api/v1/completions.ts
@@ -29,6 +29,7 @@ import {
   type FailoverConfig,
 } from "@/services/failover";
 import {
+  acceptsEventStream,
   extractUpstreamHeaders,
   filterCandidates,
   extractContentText,
@@ -569,6 +570,12 @@ export const completionsApi = new Elysia({
       // Extract extra headers for passthrough
       const extraHeaders = extractUpstreamHeaders(reqHeaders);
 
+      // Determine streaming mode. Body wins when explicit; otherwise honor
+      // the client's Accept: text/event-stream negotiation hint.
+      if (body.stream === undefined && acceptsEventStream(reqHeaders)) {
+        body.stream = true;
+      }
+
       // Check ReqId for deduplication (if provided)
       const isStream = body.stream === true;
       const reqIdResult = await checkReqId(reqId, {
@@ -718,31 +725,51 @@ export const completionsApi = new Elysia({
           extraHeaders,
         );
 
-        // Return an async generator for streaming
+        // Return a native Response with proper SSE headers. Wrapping the
+        // pre-formatted SSE generator in a ReadableStream ensures Elysia
+        // skips its auto SSE-wrapping (which would double-prefix `data:`)
+        // and lets us set Content-Type: text/event-stream explicitly.
         const streamResponse = result.response;
         const streamSignal = request.signal;
-        return (async function* () {
-          try {
-            yield* processStreamingResponse(
-              streamResponse,
-              completion,
-              bearer,
-              providerType,
-              apiKeyRecord ?? null,
-              begin,
-              streamSignal,
-              reqIdContext ?? undefined,
-            );
-          } catch (error) {
-            // Don't log error if it's due to client abort
-            if (!streamSignal.aborted) {
-              logger.error("Stream processing error", error);
-              // Note: HTTP status cannot be changed after streaming has started
-              // Use SSE format for error: data: {...}\n\n
-              yield `data: ${JSON.stringify({ error: { message: "Stream processing error", type: "server_error", code: "stream_error" } })}\n\n`;
+        const sseStream = new ReadableStream<Uint8Array>({
+          async start(controller) {
+            const encoder = new TextEncoder();
+            try {
+              for await (const chunk of processStreamingResponse(
+                streamResponse,
+                completion,
+                bearer,
+                providerType,
+                apiKeyRecord ?? null,
+                begin,
+                streamSignal,
+                reqIdContext ?? undefined,
+              )) {
+                controller.enqueue(encoder.encode(chunk));
+              }
+            } catch (error) {
+              if (!streamSignal.aborted) {
+                logger.error("Stream processing error", error);
+                controller.enqueue(
+                  encoder.encode(
+                    `data: ${JSON.stringify({ error: { message: "Stream processing error", type: "server_error", code: "stream_error" } })}\n\n`,
+                  ),
+                );
+              }
+            } finally {
+              controller.close();
             }
-          }
-        })();
+          },
+        });
+
+        return new Response(sseStream, {
+          status: 200,
+          headers: {
+            "Content-Type": "text/event-stream; charset=utf-8",
+            "Cache-Control": "no-cache",
+            Connection: "keep-alive",
+          },
+        });
       } else {
         // Non-streaming request - return JSON response directly
         const result = await executeWithFailover(

--- a/backend/src/api/v1/messages.ts
+++ b/backend/src/api/v1/messages.ts
@@ -25,6 +25,7 @@ import {
   type FailoverConfig,
 } from "@/services/failover";
 import {
+  acceptsEventStream,
   extractUpstreamHeaders,
   filterCandidates,
   extractContentText,
@@ -570,6 +571,12 @@ export const messagesApi = new Elysia({
       // Extract extra headers for passthrough
       const extraHeaders = extractUpstreamHeaders(reqHeaders);
 
+      // Determine streaming mode. Body wins when explicit; otherwise honor
+      // the client's Accept: text/event-stream negotiation hint.
+      if (body.stream === undefined && acceptsEventStream(reqHeaders)) {
+        body.stream = true;
+      }
+
       // Check ReqId for deduplication (if provided)
       const isStream = body.stream === true;
       const reqIdResult = await checkReqId(reqId, {
@@ -722,30 +729,51 @@ export const messagesApi = new Elysia({
           extraHeaders,
         );
 
-        // Return an async generator for streaming
+        // Return a native Response with proper SSE headers. Wrapping the
+        // pre-formatted SSE generator in a ReadableStream ensures Elysia
+        // skips its auto SSE-wrapping (which would double-prefix `data:`)
+        // and lets us set Content-Type: text/event-stream explicitly.
         const streamResponse = result.response;
         const streamSignal = request.signal;
-        return (async function* () {
-          try {
-            yield* processStreamingResponse(
-              streamResponse,
-              completion,
-              bearer,
-              providerType,
-              apiKeyRecord ?? null,
-              begin,
-              streamSignal,
-              reqIdContext ?? undefined,
-            );
-          } catch (error) {
-            // Don't log error if it's due to client abort
-            if (!streamSignal.aborted) {
-              logger.error("Stream processing error", error);
-              // Note: HTTP status cannot be changed after streaming has started
-              yield `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "server_error", message: "Stream processing error" } })}\n\n`;
+        const sseStream = new ReadableStream<Uint8Array>({
+          async start(controller) {
+            const encoder = new TextEncoder();
+            try {
+              for await (const chunk of processStreamingResponse(
+                streamResponse,
+                completion,
+                bearer,
+                providerType,
+                apiKeyRecord ?? null,
+                begin,
+                streamSignal,
+                reqIdContext ?? undefined,
+              )) {
+                controller.enqueue(encoder.encode(chunk));
+              }
+            } catch (error) {
+              if (!streamSignal.aborted) {
+                logger.error("Stream processing error", error);
+                controller.enqueue(
+                  encoder.encode(
+                    `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "server_error", message: "Stream processing error" } })}\n\n`,
+                  ),
+                );
+              }
+            } finally {
+              controller.close();
             }
-          }
-        })();
+          },
+        });
+
+        return new Response(sseStream, {
+          status: 200,
+          headers: {
+            "Content-Type": "text/event-stream; charset=utf-8",
+            "Cache-Control": "no-cache",
+            Connection: "keep-alive",
+          },
+        });
       } else {
         // Non-streaming request - return JSON response directly
         const result = await executeWithFailover(

--- a/backend/src/api/v1/responses.ts
+++ b/backend/src/api/v1/responses.ts
@@ -24,6 +24,7 @@ import {
   type FailoverConfig,
 } from "@/services/failover";
 import {
+  acceptsEventStream,
   extractUpstreamHeaders,
   filterCandidates,
   extractContentText,
@@ -596,6 +597,11 @@ export const responsesApi = new Elysia({
       const extraHeaders = extractUpstreamHeaders(reqHeaders);
 
       // Check ReqId for deduplication (if provided)
+      // Determine streaming mode. Body wins when explicit; otherwise honor
+      // the client's Accept: text/event-stream negotiation hint.
+      if (body.stream === undefined && acceptsEventStream(reqHeaders)) {
+        body.stream = true;
+      }
       const isStream = body.stream === true;
 
       // Convert input to messages format for storage
@@ -765,30 +771,51 @@ export const responsesApi = new Elysia({
           extraHeaders,
         );
 
-        // Return an async generator for streaming
+        // Return a native Response with proper SSE headers. Wrapping the
+        // pre-formatted SSE generator in a ReadableStream ensures Elysia
+        // skips its auto SSE-wrapping (which would double-prefix `data:`)
+        // and lets us set Content-Type: text/event-stream explicitly.
         const streamResponse = result.response;
         const streamSignal = request.signal;
-        return (async function* () {
-          try {
-            yield* processStreamingResponse(
-              streamResponse,
-              completion,
-              bearer,
-              providerType,
-              apiKeyRecord ?? null,
-              begin,
-              streamSignal,
-              reqIdContext ?? undefined,
-            );
-          } catch (error) {
-            // Don't log error if it's due to client abort
-            if (!streamSignal.aborted) {
-              logger.error("Stream processing error", error);
-              // Note: HTTP status cannot be changed after streaming has started
-              yield `event: error\ndata: ${JSON.stringify({ type: "error", error: { code: "internal_error", message: "Stream processing error", param: null, help_url: null } })}\n\n`;
+        const sseStream = new ReadableStream<Uint8Array>({
+          async start(controller) {
+            const encoder = new TextEncoder();
+            try {
+              for await (const chunk of processStreamingResponse(
+                streamResponse,
+                completion,
+                bearer,
+                providerType,
+                apiKeyRecord ?? null,
+                begin,
+                streamSignal,
+                reqIdContext ?? undefined,
+              )) {
+                controller.enqueue(encoder.encode(chunk));
+              }
+            } catch (error) {
+              if (!streamSignal.aborted) {
+                logger.error("Stream processing error", error);
+                controller.enqueue(
+                  encoder.encode(
+                    `event: error\ndata: ${JSON.stringify({ type: "error", error: { code: "internal_error", message: "Stream processing error", param: null, help_url: null } })}\n\n`,
+                  ),
+                );
+              }
+            } finally {
+              controller.close();
             }
-          }
-        })();
+          },
+        });
+
+        return new Response(sseStream, {
+          status: 200,
+          headers: {
+            "Content-Type": "text/event-stream; charset=utf-8",
+            "Cache-Control": "no-cache",
+            Connection: "keep-alive",
+          },
+        });
       } else {
         // Non-streaming request - return JSON response directly
         const result = await executeWithFailover(

--- a/backend/src/utils/api-helpers.test.ts
+++ b/backend/src/utils/api-helpers.test.ts
@@ -46,6 +46,18 @@ describe("acceptsEventStream", () => {
     expect(acceptsEventStream(h("text/event-stream;q=0.0"))).toBe(false);
   });
 
+  test("q = 0 with whitespace around = rejects SSE", () => {
+    expect(acceptsEventStream(h("text/event-stream ; q = 0"))).toBe(false);
+  });
+
+  test("q = 0.5 with whitespace around = is accepted", () => {
+    expect(acceptsEventStream(h("text/event-stream ; q = 0.5"))).toBe(true);
+  });
+
+  test("malformed empty q value is treated as not acceptable", () => {
+    expect(acceptsEventStream(h("text/event-stream;q="))).toBe(false);
+  });
+
   test("q=0 in a weighted list rejects SSE", () => {
     expect(
       acceptsEventStream(h("text/event-stream;q=0, application/json")),

--- a/backend/src/utils/api-helpers.test.ts
+++ b/backend/src/utils/api-helpers.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for api-helpers utilities
+ */
+
+import { describe, expect, test } from "bun:test";
+import { acceptsEventStream } from "./api-helpers";
+
+const h = (value?: string) => new Headers(value ? { accept: value } : {});
+
+describe("acceptsEventStream", () => {
+  test("plain text/event-stream", () => {
+    expect(acceptsEventStream(h("text/event-stream"))).toBe(true);
+  });
+
+  test("missing Accept header", () => {
+    expect(acceptsEventStream(h())).toBe(false);
+  });
+
+  test("unrelated media type", () => {
+    expect(acceptsEventStream(h("application/json"))).toBe(false);
+  });
+
+  test("wildcard does not opt in", () => {
+    expect(acceptsEventStream(h("*/*"))).toBe(false);
+  });
+
+  test("case-insensitive media type", () => {
+    expect(acceptsEventStream(h("TEXT/EVENT-STREAM"))).toBe(true);
+  });
+
+  test("tolerates internal whitespace", () => {
+    expect(acceptsEventStream(h("text/event-stream ; q = 0.5 "))).toBe(true);
+  });
+
+  test("weighted list with positive q is accepted", () => {
+    expect(
+      acceptsEventStream(h("application/json, text/event-stream;q=0.5")),
+    ).toBe(true);
+  });
+
+  test("explicit q=0 rejects SSE (RFC 7231 §5.3.1)", () => {
+    expect(acceptsEventStream(h("text/event-stream;q=0"))).toBe(false);
+  });
+
+  test("q=0.0 also rejects SSE", () => {
+    expect(acceptsEventStream(h("text/event-stream;q=0.0"))).toBe(false);
+  });
+
+  test("q=0 in a weighted list rejects SSE", () => {
+    expect(
+      acceptsEventStream(h("text/event-stream;q=0, application/json")),
+    ).toBe(false);
+  });
+
+  test("structured-suffix match is rejected", () => {
+    expect(acceptsEventStream(h("text/event-stream+json"))).toBe(false);
+  });
+
+  test("malformed q value is treated as not acceptable", () => {
+    expect(acceptsEventStream(h("text/event-stream;q=NaN"))).toBe(false);
+  });
+});

--- a/backend/src/utils/api-helpers.ts
+++ b/backend/src/utils/api-helpers.ts
@@ -64,12 +64,20 @@ export function acceptsEventStream(headers: Headers): boolean {
     if (mediaType !== "text/event-stream") {
       return false;
     }
-    const qParam = params.find((p) => p.startsWith("q="));
-    if (qParam === undefined) {
-      return true;
+    for (const param of params) {
+      const eq = param.indexOf("=");
+      if (eq === -1) {
+        continue;
+      }
+      const name = param.slice(0, eq).trim();
+      if (name !== "q") {
+        continue;
+      }
+      const value = param.slice(eq + 1).trim();
+      const q = Number(value);
+      return Number.isFinite(q) && q > 0;
     }
-    const q = Number(qParam.slice(2));
-    return Number.isFinite(q) && q > 0;
+    return true;
   });
 }
 

--- a/backend/src/utils/api-helpers.ts
+++ b/backend/src/utils/api-helpers.ts
@@ -48,17 +48,29 @@ export const EXCLUDED_HEADERS = new Set([
 
 /**
  * Whether the client is requesting an SSE stream via the Accept header.
- * Returns true for any Accept value that lists `text/event-stream`, including
- * weighted lists like `text/event-stream;q=1, application/json;q=0.5`.
+ * Matches `text/event-stream` exactly (no structured-suffix matches like
+ * `text/event-stream+json`) and respects the RFC 7231 §5.3.1 quality
+ * factor — `q=0` means "do not accept" and is filtered out.
  */
 export function acceptsEventStream(headers: Headers): boolean {
   const accept = headers.get("accept");
   if (!accept) {
     return false;
   }
-  return accept
-    .split(",")
-    .some((part) => part.trim().toLowerCase().startsWith("text/event-stream"));
+  return accept.split(",").some((part) => {
+    const [mediaType, ...params] = part
+      .split(";")
+      .map((segment) => segment.trim().toLowerCase());
+    if (mediaType !== "text/event-stream") {
+      return false;
+    }
+    const qParam = params.find((p) => p.startsWith("q="));
+    if (qParam === undefined) {
+      return true;
+    }
+    const q = Number(qParam.slice(2));
+    return Number.isFinite(q) && q > 0;
+  });
 }
 
 /**

--- a/backend/src/utils/api-helpers.ts
+++ b/backend/src/utils/api-helpers.ts
@@ -47,6 +47,21 @@ export const EXCLUDED_HEADERS = new Set([
 // =============================================================================
 
 /**
+ * Whether the client is requesting an SSE stream via the Accept header.
+ * Returns true for any Accept value that lists `text/event-stream`, including
+ * weighted lists like `text/event-stream;q=1, application/json;q=0.5`.
+ */
+export function acceptsEventStream(headers: Headers): boolean {
+  const accept = headers.get("accept");
+  if (!accept) {
+    return false;
+  }
+  return accept
+    .split(",")
+    .some((part) => part.trim().toLowerCase().startsWith("text/event-stream"));
+}
+
+/**
  * Extract headers to be forwarded to upstream
  * All headers are forwarded EXCEPT:
  * - Headers starting with "x-nexusgate-" (NexusGate-specific headers)


### PR DESCRIPTION
## Summary

- All three streaming endpoints (`/v1/chat/completions`, `/v1/responses`, `/v1/messages`) were returning `Content-Type: text/plain` instead of `text/event-stream`. Bodies were correctly SSE-formatted but the header lied, breaking strict SSE clients (browser `EventSource`, EvalScope perf benchmark, any RFC 8941 implementation).
- Switch each streaming branch to return a native `Response` wrapping a `ReadableStream`. Elysia detects pre-formatted Responses and runs `handleStream` with `skipFormat=true`, preserving our headers and bypassing 1.4's auto SSE wrapping.
- Add `Accept: text/event-stream` content negotiation: when `body.stream` is unset, an `Accept` header listing `text/event-stream` enables streaming. Body always wins when explicit.

## Root cause

When deps were bumped from `elysia ^1.3.5` to `^1.4.16` ([d1f186a](https://github.com/EM-GeekLab/NexusGate/commit/d1f186a)), the default `Content-Type` for async-generator returns silently changed from `text/event-stream` to `text/plain`. In 1.4 the auto SSE path kicks in only when `set.headers[\"content-type\"]` (lowercase) starts with `text/event-stream`, **and** it then wraps every yielded chunk with `data: \${chunk}\n\n`. Our adapters already emit pre-formatted SSE strings, so opting in to that auto path would double-prefix `data:`. Setting `set.headers[\"Content-Type\"]` (mixed case) leaves both keys live and Bun joins them as `text/event-stream, text/plain`. Returning a native `Response` is the only path in 1.4 that lets us set the header without triggering double-wrapping.

Verified against three historical versions:

| Version | Date | Elysia | `stream:true` Content-Type |
|---|---|---|---|
| `eebe5a2` | 2025-09-09 | `^1.3.5` | `text/event-stream` ✓ |
| `3223b76` | 2025-11-20 | `^1.4.16` | `text/plain` ❌ |
| `main` (this PR) | now | `^1.4.22` | `text/event-stream; charset=utf-8` ✓ |

## Test plan

- [x] `curl -D -` against `/v1/chat/completions` with `stream:true` → `Content-Type: text/event-stream; charset=utf-8`, body is valid SSE ending in `data: [DONE]\n\n`
- [x] Same for `/v1/messages` (Anthropic) → ends with `event: message_stop`
- [x] Same for `/v1/responses` (OpenAI Responses API) → events stream correctly
- [x] Non-streaming branches still return `Content-Type: application/json` (regression check)
- [x] `Accept: text/event-stream` (no `body.stream`) → streaming
- [x] `Accept: text/event-stream` + `stream:false` → JSON (body wins)
- [x] Weighted Accept list (`text/event-stream;q=1, application/json;q=0.5`) → streaming
- [x] `bun run lint` and `bun run check` pass

Closes #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 自动根据客户端 Accept 头启用事件流（SSE）传输。
  * 新增用于识别是否接受 SSE 的解析工具函数。
* **改进**
  * 流式响应改为原生 SSE 响应，显式设置 Content-Type/连接/缓存头，提升稳定性与兼容性。
  * 流内错误改为通过 SSE 事件发送并记录，改善错误可见性与连接处理。
* **测试**
  * 新增单元测试覆盖 Accept 头解析与相关行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->